### PR TITLE
Missing sq() in `clear_extrapolated_bed_level` extrapolates all mesh values during `M421 E`.

### DIFF
--- a/MPMD_3dPrinter/Marlin/Marlin_main.cpp
+++ b/MPMD_3dPrinter/Marlin/Marlin_main.cpp
@@ -2397,7 +2397,7 @@ static void clean_up_after_endstop_or_probe_move() {
     for(int i=0;i<AUTO_BED_LEVELING_GRID_POINTS;i++) {
 			float xsq = sq(i-HALF_AUTO_BED_LEVELING_GRID_POINTS)/HALF_AUTO_BED_LEVELING_GRID_POINTS;
     		for(int j=0;j<=AUTO_BED_LEVELING_GRID_POINTS;j++) {
-    			float ysq = (j-HALF_AUTO_BED_LEVELING_GRID_POINTS)/HALF_AUTO_BED_LEVELING_GRID_POINTS;
+    			float ysq = sq(j-HALF_AUTO_BED_LEVELING_GRID_POINTS)/HALF_AUTO_BED_LEVELING_GRID_POINTS;
     			float rad;
     			arm_sqrt_f32(xsq+ysq,&rad);
     			if(rad>1.0)


### PR DESCRIPTION
Found this stamping out level-assist bugs in my MPMD controller:

(aside: likely looking to merge this here eventually; works pretty well but no docs just yet)
https://github.com/anthonyrisinger/mp-mini-delta/blob/master/mpmd.py#L299-L310

Untested (setting up for that; dropping PR now), but I think it's 1/2 related to my issue:

* Some probe-able offsets impossible to save. Reproduce with `M421 I0 J3 Q...` followed by `M421 E` (will always reverts to extrapolated value). I believe this is a combination of this bug and a separate extrapolation bug.
* Some probe-able offsets saveable but improperly extrapolated if `0.0`. Affects `M421 I3 J3 Z0` (will apply extrapolation to empty center point [even if by design!]). I believe this is a separate extrapolation bug.