### PR TITLE
SD Init Fix

### DIFF
--- a/MPMD_3dPrinter/Marlin/cardreader.cpp
+++ b/MPMD_3dPrinter/Marlin/cardreader.cpp
@@ -112,6 +112,7 @@ void CardReader::initsd()
 			  sprintf((char *)buff,"code=%d\n",res);
 			  BSP_CdcIfQueueTxData(buff,sizeof(buff));
 			  release(); //test failed, loop again after releasing
+        BSP_SD_Init(); // Re-initialize the SD card
 		}
 		else {
 			f_closedir(&testroot);

--- a/MPMD_3dPrinter/Marlin/cardreader.cpp
+++ b/MPMD_3dPrinter/Marlin/cardreader.cpp
@@ -736,6 +736,10 @@ void CardReader::closefile(bool store_location)
 
 void CardReader::getfilename(uint16_t nr, const char * const match/*=NULL*/)
 {
+  initsd(); // test card
+  if(!cardOK)
+    return;
+
   curDir=&workDir;
   lsAction=LS_GetFilename;
   nrFiles=nr;
@@ -745,6 +749,10 @@ void CardReader::getfilename(uint16_t nr, const char * const match/*=NULL*/)
 
 uint16_t CardReader::getnrfilenames()
 {
+  initsd(); // test card
+  if(!cardOK)
+    return 0;
+
   curDir=&workDir;
   lsAction=LS_Count;
   nrFiles=0;


### PR DESCRIPTION
These changes allow the firmware to automatically re-initialize the SD card on M20 requests and when selecting the Print menu on the LCD. This emulates the behavior of stock firmware when printing via the SD card and the LCD.